### PR TITLE
Add Ethereum testnets, goerli and sepolia

### DIFF
--- a/lds_merkle_proof_2019/mappings.py
+++ b/lds_merkle_proof_2019/mappings.py
@@ -24,7 +24,9 @@ chain = {
     'networks': {
       'mainnet': 1,
       'ropsten': 3,
-      'rinkeby': 4
+      'rinkeby': 4,
+      'goerli': 5,
+      'sepolia': 11155111
     }
   },
   'mocknet': {


### PR DESCRIPTION
Hi maintainers,

This PR is to add the Goerli and Sepolia, which are Ethereum testnets.
We have discussed this on [this forum page](https://community.blockcerts.org/t/ethereum-announced-the-testnet-ropsten-would-be-closed-in-q4-2022/3227).
Could you check this?

## Refs

- [Goerli info](https://github.com/eth-clients/goerli)
>Network ID: 5
>Chain ID: 5

- [Sepolia info](https://github.com/eth-clients/sepolia)
>Network ID: 11155111
>Chain ID: 11155111